### PR TITLE
Allow turn off event loggin when using createHandler

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -23,7 +23,8 @@ function createHandler (f, options = {}) {
     onSuccess = doNothing,
     onError = doNothing,
     auth = Auth(),
-    cors = Cors.enabled()
+    cors = Cors.enabled(),
+    logEvent = true
   } = options
 
   return (event, context, cb) => {
@@ -32,7 +33,8 @@ function createHandler (f, options = {}) {
     // don't mutate the original event
     const normEvent = normalize(event)
     context.callbackWaitsForEmptyEventLoop = false
-    log.info(JSON.stringify(event, null, 4))
+
+    if (logEvent) log.info(JSON.stringify(event, null, 4))
 
     if (cors && !Cors.checkOrigin(normEvent)) {
       let response = HttpError(403, `Wrong Origin`)


### PR DESCRIPTION
Current creating handler with `createHandler`, it automatically logged the event. This is too verbose for development and should be able to turn off when needed.

This change allow us to do this:
```
...
const options = {
  logEvent: false
}

module.exports = {
  myFunction: createHandler(myFunction, options)
}
```